### PR TITLE
Remove Case Studies from footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -150,28 +150,12 @@
 
           <div class="footer__col">
             <div class="footer__section">
-              <h3 class="footer__title">Case studies</h3>
-              <nav class="footer__secondary-nav">
-                <ul>
-                  {% for app in site.data.apps limit:5 %}
-                  <li>
-                    <a href="{{ site.baseurl }}{{app.link}}" class="footer__secondary-link"
-                      >{{app.title}}</a
-                    >
-                  </li>
-                  {% endfor %}
-                </ul>
-              </nav>
-            </div>
-            <div class="footer__section">
               <h3 class="footer__title">Articles</h3>
               <nav class="footer__secondary-nav">
                 <ul>
                   {% for post in site.posts limit:5 %}
                   <li>
-                    <a href="{{ site.baseurl }}{{post.url}}" class="footer__secondary-link"
-                      >{{post.title}}</a
-                    >
+                    <a href="{{ site.baseurl }}{{post.url}}" class="footer__secondary-link">{{post.title}}</a>
                   </li>
                   {% endfor %}
                 </ul>


### PR DESCRIPTION
## Why 

We don't want the Case Studies in the footer. 

## What 
- [x] Remove the Case Studies section from the footer (the Articles section should move up, lined up with the Expertise and Industries)
- [ ] Discuss with TJ about his plans on having the Case Studies accessible on the website (see notes)
   - [ ] Post a comment with the summary of your discussion.

## Notes

Looks like the Case Studies will be accessible from "Our Work" page, but this needs to be confirmed. I created issue #25 for that. 
