### PR TITLE
Add a phone number to contact page

### DIFF
--- a/_includes/contact/contact.html
+++ b/_includes/contact/contact.html
@@ -13,7 +13,7 @@
 <section class="contact-form">
   <div class="container">
     <div class="contact-form-title">Let's Get Started 
-      <small>contact@ascentcore.com</small>
+      <small>(703) 867-5055 | contact@ascentcore.com</small>
     </div>
     <form
       class="contact-form__inner"

--- a/_includes/homepage/intro.html
+++ b/_includes/homepage/intro.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="intro__inner">
       <div class="intro__copy">
-        <h2 class="intro__title">We take it personally</h2>
+        <h2 class="intro__title">We take it personally!</h2>
         <p class="intro__description">
           Our success is built on personal connection at a global scale. We’ve been doing this for decades but it's never just about the project at hand. It's about building trust and driving your long-term success.
         </p>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 services:
   jekyll:
     image: jekyll/jekyll:3.8
-    command: jekyll serve --livereload --drafts
+    command: jekyll serve --livereload --drafts --force_polling
     ports:
       - 4000:4000
       - 35729:35729


### PR DESCRIPTION
## Why 

We want to provide a phone number so interested parties can reach us.

## What 
- [x] Add Larry's cell phone number to the Contact page in front of the email address

## Notes

- The contact page is available here: https://www.ascentcore.com/contact.html
- The phone number is `(703) 867-5055`
- The mockups for the contact page are available here: https://app.moqups.com/yUwnyd2GEz/edit/page/a878506ad (ask TJ to give you access if you don't have any)

Example crop from mockups:

<img width="1064" alt="Screenshot 2021-04-04 at 20 25 18" src="https://user-images.githubusercontent.com/7814406/113516680-49203000-9584-11eb-84fb-9c7f1dc0978e.png">

