### PR TITLE
Increase space between footer and content above it

### DIFF
--- a/_includes/homepage/intro.html
+++ b/_includes/homepage/intro.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="intro__inner">
       <div class="intro__copy">
-        <h2 class="intro__title">We take it personally!</h2>
+        <h2 class="intro__title">We take it personally</h2>
         <p class="intro__description">
           Our success is built on personal connection at a global scale. We’ve been doing this for decades but it's never just about the project at hand. It's about building trust and driving your long-term success.
         </p>

--- a/_includes/services/services.html
+++ b/_includes/services/services.html
@@ -219,7 +219,7 @@
       </div>
     </div>
   </div>
-  <div class="grid">
+  <div class="grid last-grid">
     <div class="grid-item">
       <img src="assets/services/icon-priv.png" />
       <h3>Data Privacy</h3>

--- a/_sass/_services.scss
+++ b/_sass/_services.scss
@@ -7,6 +7,10 @@
         margin: 0 auto;
         max-width: 950px;
 
+        &.last-grid {
+            padding-bottom: var(--space-xlarge);
+        }
+
         @media (max-width: 767px) {
             margin: var(--space-small);
         }


### PR DESCRIPTION
## Why 

There's not enough space between the footer and the content above it on the Services page. For this reason, the page is looking off. 

## What 
- [x] Increase the space between the footer and the content above it.

## Notes

Check the other pages and see how it handles the space above the footer. 

<img width="1226" alt="Screenshot 2021-04-05 at 09 47 55" src="https://user-images.githubusercontent.com/7814406/113546331-74426800-95f4-11eb-8c86-c86541fc23bf.png">
