### PR TITLE
Carrers should point out to AscentCore's Bamboo HR carreer's website

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,18 +1,18 @@
 - text: Services
-  url: services.html
+  url: /services.html
 
 - text: Our Work
-  url: work.html
+  url: /work.html
 
 - text: About Us
-  url: about.html
-
+  url: /about.html
 
 - text: Insights
-  url: insights.html
+  url: /insights.html
 
 - text: Careers
-  url: careers.html
+  external: yes
+  url: https://ascentcoreaccount.bamboohr.com/jobs/
 
 - text: Contact
-  url: contact.html
+  url: /contact.html

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,35 +25,17 @@
         <nav class="footer__nav">
           <ul>
             <li>
-              <a href="{{ site.baseurl }}/index.html" class="footer__navlink"
-                >Home</a
-              >
+              <a href="{{ site.baseurl }}" class="footer__navlink">Home</a>
             </li>
+            {% for nav in site.data.navigation %}
             <li>
-              <a href="{{ site.baseurl }}/about.html" class="footer__navlink"
-                >About</a
-              >
+              {%- if nav.external -%}
+                <a href="{{ nav.url }}" class="footer__navlink" target="_blank">{{ nav.text }}</a>
+              {%- else- %}
+                <a href="{{ site.baseurl }}{{ nav.url }}" class="footer__navlink">{{ nav.text }}</a>
+              {%- endif -%}
             </li>
-            <li>
-              <a href="{{ site.baseurl }}/services.html" class="footer__navlink"
-                >Services</a
-              >
-            </li>
-            <li>
-              <a href="{{ site.baseurl }}/work.html" class="footer__navlink"
-                >Work</a
-              >
-            </li>
-            <li>
-              <a href="{{ site.baseurl }}/careers.html" class="footer__navlink"
-                >Careers</a
-              >
-            </li>
-            <li>
-              <a href="{{ site.baseurl }}/contact.html" class="footer__navlink"
-                >Contact</a
-              >
-            </li>
+            {% endfor %}
           </ul>
         </nav>
         <div class="footer__grid">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,13 +1,13 @@
 <!-- HEADER -->
 <!-- Google Tag Manager (noscript) -->
-<noscript
-  ><iframe
+<noscript>
+  <iframe
     src="https://www.googletagmanager.com/ns.html?id=GTM-NSHFZHK"
     height="0"
     width="0"
     style="display: none; visibility: hidden"
-  ></iframe
-></noscript>
+  ></iframe>
+</noscript>
 <!-- End Google Tag Manager (noscript) -->
 <header class="header">
   <div class="container">
@@ -29,11 +29,7 @@
         {% endfor %}
 <!--        </ul>-->
       </nav>
-      <div
-        class="header__menu-trigger"
-        id="menuTrigger"
-        onclick="handleMenuTrigger()"
-      >
+      <div class="header__menu-trigger" id="menuTrigger" onclick="handleMenuTrigger()">
         <div class="header__trigger-line"></div>
         <div class="header__trigger-line"></div>
         <div class="header__trigger-line"></div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,7 +12,7 @@
 <header class="header">
   <div class="container">
     <div class="header__inner">
-      <a href="{{ site.baseurl }}/index.html" class="header__logo">ASCENTCORE</a>
+      <a href="{{ site.baseurl }}/" class="header__logo">ASCENTCORE</a>
       <nav class="header__nav">
 <!--        <ul>-->
         {% for nav in site.data.navigation %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,19 +12,22 @@
 <header class="header">
   <div class="container">
     <div class="header__inner">
-      <a href="{{ site.baseurl }}/index.html" class="header__logo"
-        >ASCENTCORE</a
-      >
+      <a href="{{ site.baseurl }}/index.html" class="header__logo">ASCENTCORE</a>
       <nav class="header__nav">
-        <ul>
-          {% for nav in site.data.navigation %}
-          <a
-            href="{{ site.baseurl }}/{{ nav.url }}"
-            class="header__link {% if nav.url == page.url %}header__link--active{% endif %}"
-            >{{ nav.text }}</a
-          >
-          {% endfor %}
-        </ul>
+<!--        <ul>-->
+        {% for nav in site.data.navigation %}
+          {%- if nav.external -%}
+            <a href="{{ nav.url }}" class="header__link" target="_blank">{{ nav.text }}</a>
+          {%- else- %}
+            {%- assign url = site.baseurl | append: nav.url -%}
+            {%- assign active = "" -%}
+            {%- if nav.url == page.url -%}
+              {%- assign active = "header__link--active" -%}
+            {%- endif -%}
+            <a href="{{ url }}" class="header__link {{ active }}">{{ nav.text }}</a>
+          {%- endif -%}
+        {% endfor %}
+<!--        </ul>-->
       </nav>
       <div
         class="header__menu-trigger"
@@ -44,15 +47,16 @@
     <div class="mobile-menu__close-line"></div>
     <div class="mobile-menu__close-line"></div>
   </div>
+
   <ul>
+    {% for nav in site.data.navigation %}
     <li>
-      {% for nav in site.data.navigation %}
-      <a
-        href="{{ site.baseurl }}/{{ nav.url }}"
-        class="mobile-menu__link {% if nav.url == page.url %}mobile-menu__link--active{% endif %}"
-        >{{ nav.text }}</a
-      >
-      {% endfor %}
+      {%- if nav.external -%}
+        <a href="{{ nav.url }}" class="mobile-menu__link" target="_blank">{{ nav.text }}</a>
+      {%- else- %}
+        <a href="{{ site.baseurl }}{{ nav.url }}" class="mobile-menu__link">{{ nav.text }}</a>
+      {%- endif -%}
     </li>
+    {% endfor %}
   </ul>
 </nav>

--- a/pages/covid-19.html
+++ b/pages/covid-19.html
@@ -7,6 +7,6 @@ title: "COVID-19"
     <div id="vis-container">
         <svg width="900" height="600" id="svg-canvas"></svg>
     </div>
-    <a class="button" href="/index.html">back to homepage</a>
+    <a class="button" href="/">back to homepage</a>
 </div>
 <script src="/assets/insights/covid-19.min.js"></script>

--- a/pages/pandemic.html
+++ b/pages/pandemic.html
@@ -58,7 +58,7 @@ title: "Pandemic Simulator"
             <a href="https://github.com/ascentcore/research/issues/new" class="btn btn-small"
               style="background-color: #FFF; color: #000; border-color: #fff; margin-right: 10px">Suggest Improvment</a>
 
-            <a href="{{site.baseurl}}/index.html" class="btn btn-small btn-error">Back To Homepage</a>
+            <a href="{{site.baseurl}}/" class="btn btn-small btn-error">Back To Homepage</a>
           </span>
         </div>
         <div class="card-body" id="simulations">


### PR DESCRIPTION
## Why

We're currently duplicating content from AscentCore's careers page to the website careers page. This is prone to errors and extra effort. The AscentCore's careers website has the entire job description -> apply for the job flow. We should use that one instead and not trying to reinvent the wheel.

## What 
- [x] Modify the Careers link to point to AscentCore's Bamboo HR jobs section

## Notes
