### PR TITLE
Add Calendly link to the main contact page per Moqups designs

### DIFF
--- a/_includes/contact/contact.html
+++ b/_includes/contact/contact.html
@@ -1,68 +1,83 @@
 <!-- HERO SECTION -->
 <section class="contact-hero">
-  <div class="container">
-    <h1 class="contact-hero__title">Contact us</h1>
-    <p class="contact-hero__description">
-      Send us a message and let us know how we can help.
-    </p>
-  </div>
-  <div class="contact-hero__image"></div>
+    <div class="container">
+        <h1 class="contact-hero__title">Contact us</h1>
+        <p class="contact-hero__description">
+            Send us a message and let us know how we can help.
+        </p>
+    </div>
+    <div class="contact-hero__image"></div>
 </section>
 
 <!-- CONTACT FORM -->
 <section class="contact-form">
-  <div class="container">
-    <div class="contact-form-title">Let's Get Started 
-      <small>(703) 867-5055 | contact@ascentcore.com</small>
-    </div>
-    <form
-      class="contact-form__inner"
-      action="https://formspree.io/f/mbjzydzp"
-      method="POST"
-    >
-    <div class="contact-form__group">
-      <label>
-          Your email: <input type="email" name="_replyto" />
-      </label>
-    </div>
-    <div class="contact-form__group">
-      <label>
-          Your phone: <input type="text" name="phone" />
-      </label>
-    </div>
-    <div class="contact-form__group">
-      <label>
-        Your message:
-        <textarea name="message" rows="10"></textarea>
-      </label>
-    </div>
+    <div class="container">
+        <div class="contact-form__title">Let's Get Started
+            <small>(703) 867-5055 | contact@ascentcore.com</small>
+        </div>
+        <div class="contact-form__wrapper">
+            <form class="contact-form__inner" action="https://formspree.io/f/mbjzydzp" method="POST">
+                <div class="contact-form__group">
+                    <div class="contact-form__field"><input type="text" name="name" placeholder="Name" /></div>
+                    <div class="contact-form__field"><input type="text" name="company" placeholder="Company" /></div>
+                    <div class="contact-form__field"><input type="email" name="_replyto" placeholder="Email" /></div>
+                    <div class="contact-form__field"><input type="text" name="phone" placeholder="Phone" /></div>
+                    <div class="contact-form__textarea"><textarea name="message" rows="1" placeholder="Tell us about your project"></textarea></div>
+                </div>
 
-      <!-- your other form fields go here -->
+                <!-- your other form fields go here -->
 
-      <button class="contact-form__submit" type="submit">Send</button>
-    </form>
-
+                <div class="contact-form__button">
+                    <button class="contact-form__submit" type="submit">Submit</button>
+                </div>
+            </form>
+            <div class="schedule-call">
+                <h3>Schedule a call now</h3>
+                <p>Use our automated scheduling tool to setup a conversation with our engineering team.</p>
+                <a href="#" class="schedule-call__button">Scheduling tool</a>
+            </div>
+        </div>
 </section>
+
+<!-- OTHER WAYS TO GET STARTED -->
+<section class="other-ways">
+    <div class="container">
+        <h2>Other ways to get started</h2>
+        <div class="other-ways__wrapper">
+            <div class="other-ways__column">
+                <h3>Technical Assessment</h3>
+                <p>Before developing an existing product, a detailed assessment may be recommended in order to evaluate product performance in relation to its essential characteristics.</p>
+                <a href="#" class="other-ways__start">Start a conversation</a>
+            </div>
+            <div class="other-ways__column">
+                <h3>Risk Analysis</h3>
+                <p>Our expert team can help you identify risks and their triggers, classify and prioritize all risks, and implement mitigating action if any risk materializes.</p>
+                <a href="#" class="other-ways__start">Start a conversation</a>
+            </div>
+        </div>
+    </div>
+</section>
+
 
 <!-- LOCATION -->
 <section class="contact-locations">
-  <div class="container">
-    <h2>Our locations </h2>
-    <div class="contact-locations__inner">
-      <div class="contact-locations__item">
-        <!-- <div class="contact-locations__image--reston"></div> -->
-        <h3>Reston</h3>
-        <p>1284 Auburn Grove Ln, Suite 100</p>
-        <p>Reston, VA 20194, USA</p>
-        <a href="mailto:contact@ascentcore.com">contact@ascentcore.com</a>
-      </div>
-      <div class="contact-locations__item">
-        <!-- <div class="contact-locations__image--cluj"></div> -->
-        <h3>Cluj-Napoca</h3>
-        <p>Nicolae Draganu Nr.4</p>
-        <p>Jud. Cluj, Romania</p>
-        <a href="mailto:contact@ascentcore.com">contact@ascentcore.com</a>
-      </div>
+    <div class="container">
+        <h2>Our locations </h2>
+        <div class="contact-locations__inner">
+            <div class="contact-locations__item">
+                <!-- <div class="contact-locations__image--reston"></div> -->
+                <h3>Reston</h3>
+                <p>1284 Auburn Grove Ln, Suite 100</p>
+                <p>Reston, VA 20194, USA</p>
+                <a href="mailto:contact@ascentcore.com">contact@ascentcore.com</a>
+            </div>
+            <div class="contact-locations__item">
+                <!-- <div class="contact-locations__image--cluj"></div> -->
+                <h3>Cluj-Napoca</h3>
+                <p>Nicolae Draganu Nr.4</p>
+                <p>Jud. Cluj, Romania</p>
+                <a href="mailto:contact@ascentcore.com">contact@ascentcore.com</a>
+            </div>
+        </div>
     </div>
-  </div>
 </section>

--- a/_includes/contact/contact.html
+++ b/_includes/contact/contact.html
@@ -34,7 +34,7 @@
             <div class="schedule-call">
                 <h3>Schedule a call now</h3>
                 <p>Use our automated scheduling tool to setup a conversation with our engineering team.</p>
-                <a href="#" class="schedule-call__button">Scheduling tool</a>
+                <a href="https://calendly.com/ascentcore" class="schedule-call__button">Scheduling tool</a>
             </div>
         </div>
 </section>
@@ -47,12 +47,12 @@
             <div class="other-ways__column">
                 <h3>Technical Assessment</h3>
                 <p>Before developing an existing product, a detailed assessment may be recommended in order to evaluate product performance in relation to its essential characteristics.</p>
-                <a href="#" class="other-ways__start">Start a conversation</a>
+                <a href="https://calendly.com/ascentcore" class="other-ways__start">Start a conversation</a>
             </div>
             <div class="other-ways__column">
                 <h3>Risk Analysis</h3>
                 <p>Our expert team can help you identify risks and their triggers, classify and prioritize all risks, and implement mitigating action if any risk materializes.</p>
-                <a href="#" class="other-ways__start">Start a conversation</a>
+                <a href="https://calendly.com/ascentcore" class="other-ways__start">Start a conversation</a>
             </div>
         </div>
     </div>

--- a/_sass/_contact.scss
+++ b/_sass/_contact.scss
@@ -1,14 +1,12 @@
 .contact {
     /* --------------------- Contact page styles --------------------- */
-
-    .contact-form-title {
+    .contact-form__title {
         display: block;
         color: var(--color-orange);
         font-size: var(--text-medium-titles);
         font-weight: bold;
         text-align: center;
-        padding: var(--space-large) 0;
-
+        padding: 0 0 var(--space-large) 0;
         small {
             display: block;
             font-weight: 100;
@@ -16,26 +14,21 @@
             color: var(--color-dark-gray)
         }
     }
-
-
-    /* Hero section */
+    /* Hero Section */
     .contact-hero {
         position: relative;
         padding: var(--space-xlarge) 0 var(--space-xlarge);
     }
-
     .contact-hero__title {
         font-size: var(--text-big-titles);
         padding: 0;
         margin: 0 0 var(--space-xsmall) 0;
     }
-
     .contact-hero__description {
         font-size: var(--text-large);
         padding: 0;
         margin: 0;
     }
-
     .contact-hero__image {
         position: absolute;
         width: 100%;
@@ -48,7 +41,6 @@
         background-position: center center;
         background-attachment: fixed;
     }
-
     @media (max-width: 1120px) {
         .contact-hero__image {
             background-size: cover;
@@ -56,91 +48,178 @@
             background-attachment: scroll;
         }
     }
-
-
-    .contact-form__inner {
-        background: #fff;
-        max-width: 520px;
-        padding: var(--space-large);
+    /* Contact form Section */
+    .contact-form {
+        padding: var(--space-xlarge) 0;
+        @media (max-width: 820px) {
+            padding: var(--space-large) 0;
+        }
+        .contact-form__wrapper {
+            display: flex;
+            flex-wrap: wrap;
+            @media (max-width: 820px) {
+                display: block;
+            }
+            .contact-form__inner {
+                width: 50%;
+                box-sizing: border-box;
+                background: #fff;
+                @media (max-width: 820px) {
+                    width: 100%;
+                }
+                .contact-form__group {
+                    margin-bottom: var(--space-xsmall);
+                    display: flex;
+                    flex-wrap: wrap;
+                    .contact-form__field {
+                        width: 50%;
+                        box-sizing: border-box;
+                        padding: var(--space-xxsmall);
+                        @media (max-width: 820px) {
+                            width: 100%;
+                        }
+                        input {
+                            width: 100%;
+                            height: 45px;
+                            box-sizing: border-box;
+                            padding: 10px 0;
+                            margin-top: var(--space-xxsmall);
+                            border: 0;
+                            border-bottom: 1px solid var(--color-medium-gray);
+                            border-radius: 0 !important;
+                            outline: none !important;
+                            &:focus {
+                                border-bottom: 1px solid var(--color-blue);
+                            }
+                        }
+                    }
+                    .contact-form__textarea {
+                        width: 100%;
+                        box-sizing: border-box;
+                        padding: var(--space-xxsmall);
+                        textarea {
+                            width: 100%;
+                            padding: 10px 0;
+                            box-sizing: border-box;
+                            margin-top: var(--space-xxsmall);
+                            border: 0;
+                            border-bottom: 1px solid var(--color-medium-gray);
+                            border-radius: 0 !important;
+                            outline: none !important;
+                            resize: vertical;
+                            &:focus {
+                                border-bottom: 1px solid var(--color-blue);
+                            }
+                        }
+                    }
+                }
+                .contact-form__button {
+                    padding: var(--space-xxsmall);
+                    .contact-form__submit {
+                        cursor: pointer;
+                        border: 0px solid var(--color-blue);
+                        padding: var(--space-xsmall) var(--space-large);
+                        font-weight: bold;
+                        border-radius: 0px;
+                        color: var(--color-blue);
+                        background-color: var(--color-light-gray);
+                        text-decoration: none;
+                        width: 100%;
+                    }
+                    .contact-form__submit:hover {
+                        background: var(--color-blue);
+                        color: var(--color-white-blue);
+                    }
+                }
+            }
+            .schedule-call {
+                width: 50%;
+                box-sizing: border-box;
+                padding: var(--space-small) var(--space-large);
+                text-align: center;
+                color: var(--color-blue);
+                @media (max-width: 820px) {
+                    width: 100%;
+                }
+                .schedule-call__button {
+                    display: inline-block;
+                    border: 1px solid var(--color-orange);
+                    margin-top: var(--space-small);
+                    padding: var(--space-xsmall) var(--space-large);
+                    font-size: var(--text-large);
+                    font-weight: bold;
+                    border-radius: 10px;
+                    color: var(--color-orange);
+                    text-decoration: none;
+                    @media (max-width: 820px) {
+                        padding: var(--space-xsmall) var(--space-medium);
+                    }
+                }
+            }
+        }
     }
-
-    .contact-form__group {
-        margin-bottom: var(--space-xsmall);
-    }
-
-    .contact-form__group label {
-        display: block;
-        font-weight: bold;
-        margin-bottom: var(--space-small);
-    }
-
-    .contact-form__group input {
-        height: 45px;
-        box-sizing: border-box;
-        width: 100%;
-        padding: 15px;
-        margin-top: var(--space-xxsmall);
-        border: 1px solid var(--color-dark-gray);
-        border-radius: 0 !important;
-        outline: none !important;
-    }
-
-    .contact-form__group input:focus {
-        border-left: 3px solid var(--color-blue) !important;
-        border-radius: 0 !important;
-    }
-
-    .contact-form__group textarea {
-        width: 100%;
-        padding: 15px;
-        box-sizing: border-box;
-        margin-top: var(--space-xxsmall);
-        border: 1px solid var(--color-dark-gray);
-        border-radius: 0 !important;
-        outline: none !important;
-        resize: vertical;
-    }
-
-    .contact-form__submit {
-        cursor: pointer;
-        border: 1px solid var(--color-blue);
-        padding: var(--space-xsmall) var(--space-large);
-        font-weight: bold;
-        border-radius: 10px;
+    /* Other ways to get started Section */
+    .other-ways {
+        background-color: var(--color-light-gray);
+        padding: var(--space-large) 0;
         color: var(--color-blue);
-        background-color: var(--color-white);
-        text-decoration: none;
-        margin-left: auto;
+        h2 {
+            font-size: var(--text-medium-titles);
+            text-align: center;
+            @media (max-width: 820px) {
+                text-align: left;
+            }
+        }
+        .other-ways__wrapper {
+            display: flex;
+            flex-wrap: wrap;
+            padding: var(--space-small) var(--space-xlarge);
+            @media (max-width: 820px) {
+                display: block;
+                padding: var(--space-small) 0;
+            }
+            .other-ways__column {
+                width: 50%;
+                box-sizing: border-box;
+                padding: 0 var(--space-large);
+                @media (max-width: 820px) {
+                    width: 100%;
+                    padding: 0 0 var(--space-small) 0;
+                }
+                .other-ways__start {
+                    font-size: var(--text-large);
+                    font-weight: bold;
+                    text-decoration: underline;
+                    &::after {
+                        font-family: "Font Awesome 5 Free";
+                        content: "\f061";
+                        color: var(--color-orange);
+                        position: absolute;
+                        margin-left: 10px;
+                    }
+                }
+            }
+        }
     }
-
-    .contact-form__submit:hover {
-        background: var(--color-blue);
-        color: var(--color-white-blue);
-    }
-
     /* Locations section */
     .contact-locations {
         padding: var(--space-xlarge) 0;
-        background: var(--color-light-gray);
+        background: var(--color-medium-gray);
     }
-
     .contact-locations h2 {
         font-size: var(--text-medium-titles);
         padding: 0;
         margin: 0 0 var(--space-large) 0;
         color: var(--color-blue);
     }
-
     .contact-locations__inner {
         display: flex;
         flex-wrap: wrap;
         justify-content: space-between;
     }
-
     .contact-locations__item {
         width: calc(50% - var(--space-medium));
     }
-
     .contact-locations__image--cluj {
         width: 100%;
         height: 320px;
@@ -148,7 +227,6 @@
         background-size: cover;
         background-position: center center;
     }
-
     .contact-locations__image--reston {
         width: 100%;
         height: 320px;
@@ -156,17 +234,14 @@
         background-size: cover;
         background-position: center center;
     }
-
     .contact-locations__item h3 {
         margin: var(--space-small) 0 var(--space-xxsmall);
         padding: 0;
     }
-
     .contact-locations__item p {
         margin: 0;
         padding: 0;
     }
-
     .contact-locations__item a {
         font-weight: bold;
         text-decoration: none;
@@ -176,7 +251,6 @@
         display: inline-block;
         margin: var(--space-small) 0 0 0;
     }
-
     @media (max-width: 820px) {
         .contact-form__inner {
             padding-left: 0;
@@ -184,7 +258,6 @@
             margin: 0;
             border: none;
         }
-
         .contact-locations__item {
             width: 100%;
             margin-bottom: var(--space-medium);


### PR DESCRIPTION
## Why 

We want people to be able to schedule a call using Calendly

## What 
- [x] Add the "Schedule a call now" section to the Contact page as per the mockups (see notes)
- [x] Replace the "Scheduling tool" with a button that will integrate Calendly
   - [x] Ask TJ to send the Calendly credentials

## Notes

Mockup for the contact page: https://app.moqups.com/yUwnyd2GEz/edit/page/a878506ad

