### PR TITLE
Custom 404 page needed

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,28 @@
+---
+layout: default
+title: 404
+---
+
+<div class="page-404">
+    <div class="container">
+        <div class="page-404__title">
+            <h1>Well, this is awkward! </h1>
+            <h2>We cannot find the page you are looking for.</h2>
+        </div>
+        <div class="page-404__description">
+            <h4>What could have caused this?</h4>
+            <ul>
+                <li>We might have removed the page when we redesigned our website</li>
+                <li>The link you clicked might be old and doesn’t exist anymore</li>
+                <li>You might have accidentally typed a wrong URL link in the address bar</li>
+                <li>Something technical went wrong on our website</li>
+            </ul>
+        </div>
+        <div class="page-404__description">
+            <h4>What you can do?</h4>
+            <p><a href="/">Go back to our homepage</a></p>
+            <p><a href="/services.html">Learn about our services:</a></p>
+            <p>Check out some of the latest articles on our <a href="/insights.html">blog</a> or <a href="/contact.html">contact</a> us if you need any help at all.</p>
+        </div>
+    </div>
+</div>

--- a/_sass/_error-page.scss
+++ b/_sass/_error-page.scss
@@ -1,0 +1,39 @@
+/* --------------------- 404 Error Page styles --------------------- */
+
+.page-404 {
+    background-color: var(--color-light-gray);
+    padding: var(--space-large) 0;
+    position: relative;
+    .page-404__title {
+        text-align: center;
+        padding-bottom: var(--space-medium);
+        h1, h2 {
+            color: var(--color-blue);
+        }
+    }
+    .page-404__description {
+        padding: var(--space-xsmall) 0;
+        h4 {
+            margin: 0;
+        }
+        ul {
+            list-style-type: disc;
+            li {
+                line-height: 1.7;
+            }
+        }
+    }
+    &::after {
+        content: "A";
+        position: absolute;
+        color: var(--color-blue);
+        font-weight: bold;
+        opacity: 0.02;
+        font-size: 72em;
+        top: -520px;
+        left: -200px;
+        @media (max-width: 700px) {
+            display: none;
+        }
+    }
+}

--- a/assets/ascentcore.scss
+++ b/assets/ascentcore.scss
@@ -16,3 +16,4 @@ sitemap: false;
 @import "code";
 @import "post";
 @import "services-ai";
+@import "error-page";


### PR DESCRIPTION
## Why 

As we add and remove content on our website, like job openings, we can expect that some links will not work in the future. A dedicated 404 page will help reduce the bounce rate by guiding users to the key areas of interest on our website. 

## What 
- [ ] Create a custom 404 page for our website.
- [ ] Add a link to the homepage
- [ ] Add links to the job openings page
- [ ] Add a link to the contact page

## Notes

When a visitor hits a not found endpoint on our site, the 404 custom page will load and will present the user with options:
- Go to our home page
- Are you looking for a job opening? Check out the career page or the active jobs [list]
- Are you looking for our contact details? Go to the Contact Us page. 

Currently, the GitHub pages default 404 is displayed and that isn't helping visitors:

<img width="685" alt="Screenshot 2021-04-05 at 09 52 19" src="https://user-images.githubusercontent.com/7814406/113546846-7a851400-95f5-11eb-951c-8a1b0070890a.png">


